### PR TITLE
Add codes for LLM4Chem dataset

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,9 @@ transformers
 typing_extensions
 validators
 xlsxwriter
+# TODO: newly added dependencies
+datasets
+rdkit
+rdchiral
+rouge_score
+scikit-learn

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -84,6 +84,7 @@ from .mmhelix import MMHELIX
 from .medqbench_mcq import MedqbenchMCQDataset
 from .medqbench_caption import MedqbenchCaptionDataset
 from .medqbench_paired_description import MedqbenchPairedDescriptionDataset
+from .llm4chem import LLM4Chem
 
 
 class ConcatDataset(ImageBaseDataset):
@@ -103,6 +104,7 @@ class ConcatDataset(ImageBaseDataset):
         'ScreenSpot': ['ScreenSpot_Mobile', 'ScreenSpot_Desktop', 'ScreenSpot_Web'],
         'ScreenSpot_v2': ['ScreenSpot_v2_Mobile', 'ScreenSpot_v2_Desktop', 'ScreenSpot_v2_Web'],
         'M4Bench': ['State_Invariance', 'State_Comparison', 'Spatial_Perception', 'Instance_Comparison', 'Detailed_Difference'],  # noqa: E501
+        'LLM4Chem' : ['forward_synthesis', 'retrosynthesis', 'molecule_captioning', 'molecule_generation', 'name_conversion-i2f', 'name_conversion-i2s', 'name_conversion-s2f', 'name_conversion-s2i', 'property_prediction-esol', 'property_prediction-lipo', 'property_prediction-bbbp', 'property_prediction-clintox', 'property_prediction-hiv', 'property_prediction-sider', 'retrosynthesis_uspto50k'],
     }
 
     def __init__(self, dataset):
@@ -228,7 +230,8 @@ VIDEO_DATASET = [
 ]
 
 TEXT_DATASET = [
-    TextMCQDataset
+    TextMCQDataset,
+    LLM4Chem,
 ]
 
 CUSTOM_DATASET = [

--- a/vlmeval/dataset/llm4chem.py
+++ b/vlmeval/dataset/llm4chem.py
@@ -1,0 +1,181 @@
+import warnings
+import pandas as pd
+import re
+from abc import abstractmethod
+from sklearn.metrics import matthews_corrcoef, accuracy_score, r2_score, roc_auc_score, precision_score, recall_score, mean_absolute_error
+from ..smp import *
+from .text_base import TextBaseDataset
+from .utils.llm4chem.utils.metrics import calculate_smiles_metrics, calculate_formula_metrics, calculate_text_metrics, calculate_number_metrics, calculate_boolean_metrics
+from .utils.llm4chem.config import TASKS, TASK_TAGS, TASKS_WITH_SEMICOLON_REPLACE
+
+# TODO: Now only support Top1 evaluation for generation tasks, need to support TopK evaluation in the future
+
+# TODO: Modify the root path to https://opencompass.openxlab.space/ ... as needed
+# TODO: See tos://tos-bjml-ai4scilab/scievalkit_benchmark/LLM4Chem/
+DATASET_ROOT_PATH = "LLM4Chem/"
+
+def extract_answer_part(outputs, left_tag, right_tag, mode='tag'):
+    assert mode in ('tag', 'direct')
+
+    assert isinstance(outputs, list)
+    answers = []
+    for text in outputs:
+        if mode == 'direct' or (left_tag is None and right_tag is None):
+            text = text.replace('<unk>', '').replace('</s>', '').strip()
+            answers.append(text.strip())
+            continue
+        
+        left_tag_pos = text.find(left_tag)
+        if left_tag_pos == -1:
+            answers.append('')
+            continue
+        right_tag_pos = text.find(right_tag)
+        if right_tag_pos == -1:
+            answers.append('')
+            continue
+        text = text[left_tag_pos + len(left_tag): right_tag_pos].strip()
+        answers.append(text)
+    return answers
+
+def LLM4Chem_postprocess(text, task, *args, **kwargs):
+    # delete content within <think> </think>
+    text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL)
+    replace_semicolon = task in TASKS_WITH_SEMICOLON_REPLACE
+    pred = extract_answer_part([text], *(TASK_TAGS[task]), mode='tag')[0]
+    # task in TASKS_WITH_SEMICOLON_REPLACE needs semicolon replaced with a period
+    if replace_semicolon:
+        pred = pred.replace(';', '.')
+    # no matched tag
+    if pred == '':
+        tag = TASK_TAGS[task][0]
+
+        if (tag == '<BOOLEAN>'):
+            # find the last yes/true/no/false in text, case insensitive
+            ans = re.findall(r'\b(?:yes|true|no|false)\b', text, re.IGNORECASE)
+            if ans:
+                # if ans[-1] is yes/true
+                if ans[-1].lower() in ('yes', 'true'):
+                    return 'Yes'
+                else:
+                    return 'No'
+            else:
+                return ''
+
+        if (tag == '<NUMBER>'):
+            # find the last number in text
+            # remove content within <SMILES> </SMILES> from text
+            text_2 = re.sub(r'<SMILES>.*?</SMILES>', '', text, flags=re.DOTALL)
+            ans = re.findall(r'-?\d*\.\d+|-?\d+', text_2)
+            if ans:
+                return ans[-1]
+            else:
+                return ''
+
+        if (tag == '<MOLFORMULA>'):
+            # find the last chemical formula in text
+            ans = re.findall(r'[\[\(]?[A-Z][a-z]?\d*(?:\([A-Za-z0-9]+\)\d*)?[\]\)]?(?:[A-Z][a-z]?\d*|\([^\)]+\)\d*|\[[^\]]+\]\d*)*(?:[+-]{1,2})?(?:·\d*[A-Z][a-z]?\d*)*', text)
+            if ans:
+                return ans[-1]
+            else:
+                return ''
+            
+                
+    # print(f"prediction: {pred}")
+    return pred
+
+# WARNING: You should ensure the Internet is connected while running this function for the first time.
+def download_nltk():
+    import nltk
+    conda_prefix = os.environ.get('CONDA_PREFIX', None)
+    if conda_prefix is not None:
+        nltk_data_dir = os.path.join(conda_prefix, 'nltk_data')
+        nltk.download('wordnet', download_dir=nltk_data_dir, quiet=True)
+        nltk.data.path.append(nltk_data_dir)
+    else:
+        nltk.download('wordnet', quiet=True)
+        nltk_data_dir = '~/nltk_data'
+    print(f"NLTK 'wordnet' downloaded to: {nltk_data_dir}")
+
+class LLM4Chem(TextBaseDataset):
+    TYPE = 'TEXT'
+
+    DATASET_URL = {
+        # TODO: DATASET_ROOT_PATH is a placeholder, need to modify to actual path or URL
+        task: DATASET_ROOT_PATH + f"LLM4Chem_{task}.tsv" for task in TASKS
+    }
+
+    DATASET_MD5 = {
+        task : None for task in TASKS
+    }
+
+    # It returns a DataFrame
+    @classmethod 
+    def evaluate(self, eval_file, **judge_kwargs):
+
+        result_values = []
+        label_values = []
+        data = load(eval_file)
+        data= data[~pd.isna(data["prediction"])]
+        assert 'answer' in data and 'prediction' in data 
+        dataset_name = None
+        for name in self.DATASET_URL:
+            if name in eval_file:
+                dataset_name = name
+                break
+        task = dataset_name
+        answers = []
+        predictions = []
+        for index,entry in data.iterrows():
+            answers.append(LLM4Chem_postprocess(str(entry['answer']), task))
+            predictions.append(LLM4Chem_postprocess(str(entry['prediction']), task))
+        
+        answers = [[ans] for ans in answers]
+        predictions = [[pred] for pred in predictions]
+        # TODO: Now the following code support TopK evaluation, but from EvalKit framework, we cannot get K generated answers.
+
+        pred_list = predictions
+        gold_list = answers
+
+        if (task == 'molecule_captioning'):
+            download_nltk() # Ensure NLTK wordnet is downloaded
+
+        if task in ('property_prediction-esol', 'property_prediction-lipo', 'property_prediction-bbbp', 'property_prediction-clintox', 'property_prediction-hiv', 'property_prediction-sider'):
+            # set pred_list to [length * 1]
+            pred_list = [[pred[0]] for pred in pred_list]
+
+        if task in ('forward_synthesis', 'molecule_generation', 'name_conversion-i2s'):
+            r = calculate_smiles_metrics(pred_list, gold_list)
+        elif task in ('retrosynthesis', 'retrosynthesis_uspto50k'):
+            r = calculate_smiles_metrics(pred_list, gold_list, metrics=('exact_match', 'fingerprint', 'multiple_match'))
+        elif task in ('molecule_captioning',):
+            r = calculate_text_metrics(
+                pred_list,
+                gold_list,
+                text_model='allenai/scibert_scivocab_uncased',
+                text_trunc_length=2048,
+            )
+        elif task in ('name_conversion-i2f', 'name_conversion-s2f'):
+            r = calculate_formula_metrics(pred_list, gold_list, metrics=('element_match',))
+        elif task in ('name_conversion-s2i',):
+            r = calculate_formula_metrics(pred_list, gold_list, metrics=('split_match',))
+        elif task in ('property_prediction-esol', 'property_prediction-lipo'):
+            r = calculate_number_metrics(pred_list, gold_list)
+        elif task in ('property_prediction-bbbp', 'property_prediction-clintox', 'property_prediction-hiv', 'property_prediction-sider'):
+            r = calculate_boolean_metrics(pred_list, gold_list)
+        else:
+            raise ValueError(task)
+
+        if 'num_t1_exact_match' in r and 'num_all' in r:
+            r['top1_exact_match'] = round(r['num_t1_exact_match'] / r['num_all'] * 100, 2)
+        if 'num_t5_exact_match' in r and 'num_all' in r:
+            r['top5_exact_match'] = round(r['num_t5_exact_match'] / r['num_all'] * 100, 2)
+        if 'num_t1_ele_match' in r and 'num_all' in r:
+            r['top1_ele_match'] = round(r['num_t1_ele_match'] / r['num_all'] * 100, 2)
+        if 'num_correct' in r and 'num_all' in r:
+            r['accuracy'] = round(r['num_correct'] / r['num_all'] * 100, 2)
+        if 'num_t1_split_match' in r and 'num_all' in r:
+            r['top1_split_match'] = round(r['num_t1_split_match'] / r['num_all'] * 100, 2)
+        if 'num_t5_split_match' in r and 'num_all' in r:
+            r['top5_split_match'] = round(r['num_t5_split_match'] / r['num_all'] * 100, 2)
+
+        return r

--- a/vlmeval/dataset/utils/llm4chem/config.py
+++ b/vlmeval/dataset/utils/llm4chem/config.py
@@ -1,0 +1,168 @@
+# https://github.com/OSU-NLP-Group/LLM4Chem
+# https://github.com/otori-bird/retrosynthesis
+
+TASKS = (
+    'forward_synthesis',
+    'retrosynthesis',
+    'molecule_captioning',
+    'molecule_generation',
+    'name_conversion-i2f',
+    'name_conversion-i2s',
+    'name_conversion-s2f',
+    'name_conversion-s2i',
+    'property_prediction-esol',
+    'property_prediction-lipo',
+    'property_prediction-bbbp',
+    'property_prediction-clintox',
+    'property_prediction-hiv',
+    'property_prediction-sider',
+    'retrosynthesis_uspto50k',
+)
+
+
+DEFAULT_MAX_INPUT_TOKENS = 512
+DEFAULT_MAX_NEW_TOKENS = 1024
+
+
+TASKS_GENERATION_SETTINGS = {
+    'forward_synthesis': {
+        'generation_kargs': {
+            'num_return_sequences': 5,
+            'num_beams': 8
+        },
+    },
+    'retrosynthesis': {
+        'max_new_tokens': 960,
+        'generation_kargs': {
+            'num_return_sequences': 10,
+            'num_beams': 13
+        },
+    },
+    'molecule_captioning': {
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4
+        },
+    },
+    'molecule_generation': {
+        'generation_kargs': {
+            'num_return_sequences': 5,
+            'num_beams': 8
+        },
+    },
+    'name_conversion-i2f': {
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 3,
+            'num_beams': 6
+        },
+    },
+    'name_conversion-i2s': {
+        'generation_kargs': {
+            'num_return_sequences': 5,
+            'num_beams': 8
+        },
+    },
+    'name_conversion-s2f': {
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 3,
+            'num_beams': 6
+        },
+    },
+    'name_conversion-s2i': {
+        'generation_kargs': {
+            'num_return_sequences': 5,
+            'num_beams': 8
+        },
+    },
+    'property_prediction-esol': {
+        'batch_size': 16,
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4,
+        },
+    },
+    'property_prediction-lipo': {
+        'batch_size': 16,
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4,
+        },
+    },
+    'property_prediction-bbbp': {
+        'batch_size': 16,
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4,
+        },
+    },
+    'property_prediction-clintox': {
+        'batch_size': 16,
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4,
+        },
+    },
+    'property_prediction-hiv': {
+        'batch_size': 16,
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4,
+        },
+    },
+    'property_prediction-sider': {
+        'batch_size': 16,
+        'max_new_tokens': 20,
+        'generation_kargs': {
+            'num_return_sequences': 1,
+            'num_beams': 4,
+        },
+    },
+}
+
+
+TASK_TAGS = {
+    'forward_synthesis': ('<SMILES>', '</SMILES>'),
+    'retrosynthesis': ('<SMILES>', '</SMILES>'),
+    'molecule_generation': ('<SMILES>', '</SMILES>'),
+    'molecule_captioning': (None, None),
+    'name_conversion-i2f': ('<MOLFORMULA>', '</MOLFORMULA>'),
+    'name_conversion-i2s': ('<SMILES>', '</SMILES>'),
+    'name_conversion-s2f': ('<MOLFORMULA>', '</MOLFORMULA>'),
+    'name_conversion-s2i': ('<IUPAC>', '</IUPAC>'),
+    'property_prediction-esol': ('<NUMBER>', '</NUMBER>'),
+    'property_prediction-lipo': ('<NUMBER>', '</NUMBER>'),
+    'property_prediction-bbbp': ('<BOOLEAN>', '</BOOLEAN>'),
+    'property_prediction-clintox': ('<BOOLEAN>', '</BOOLEAN>'),
+    'property_prediction-hiv': ('<BOOLEAN>', '</BOOLEAN>'),
+    'property_prediction-sider': ('<BOOLEAN>', '</BOOLEAN>'),
+    'retrosynthesis_uspto50k': ('<SMILES>', '</SMILES>'),
+}
+
+
+# These tasks output SMILES, where there may be semicolons that separate different parts. To facilitate evaluation, each semicolon is replaced by a dot.
+TASKS_WITH_SEMICOLON_REPLACE = ('forward_synthesis', 'retrosynthesis', 'molecule_generation', 'name_conversion-i2s', 'retrosynthesis_uspto50k')
+
+
+# For these tasks, one input might have multiple gold answers, so the gold answer should be directly obtained from the dataset instead of directly using the gold domain of each sample.
+TASKS_WITH_READING_GOLD_FROM_DATASET = (
+    'forward_synthesis', 'retrosynthesis', 
+    'molecule_generation', 'molecule_captioning', 
+    'name_conversion-i2f', 'name_conversion-i2s',
+    'name_conversion-s2f', 'name_conversion-s2i',
+    'retrosynthesis_uspto50k',
+)
+
+
+BASE_MODELS = {
+    'osunlp/LlaSMol-Mistral-7B': 'mistralai/Mistral-7B-v0.1',
+    'osunlp/LlaSMol-Galactica-6.7B': 'facebook/galactica-6.7b',
+    'osunlp/LlaSMol-Llama2-7B': 'meta-llama/Llama-2-7b-hf',
+    'osunlp/LlaSMol-CodeLlama-7B': 'codellama/CodeLlama-7b-hf',
+}

--- a/vlmeval/dataset/utils/llm4chem/utils/__input__.py
+++ b/vlmeval/dataset/utils/llm4chem/utils/__input__.py
@@ -1,0 +1,1 @@
+import smiles_canonicalization

--- a/vlmeval/dataset/utils/llm4chem/utils/chat_generation.py
+++ b/vlmeval/dataset/utils/llm4chem/utils/chat_generation.py
@@ -1,0 +1,9 @@
+def generate_chat(input_text, output_text=None, prefix_chat=None):
+    chat = [
+        {"role": "user", "content": input_text},
+    ]
+    if output_text is not None:
+        chat.append({"role": "assistant", "content": output_text})
+    if prefix_chat is not None:
+        chat = prefix_chat + chat
+    return chat

--- a/vlmeval/dataset/utils/llm4chem/utils/core_tagger.py
+++ b/vlmeval/dataset/utils/llm4chem/utils/core_tagger.py
@@ -1,0 +1,172 @@
+import json
+import os
+
+
+def find_sub_sequence(whole, sub):
+    assert isinstance(whole, list)
+    assert isinstance(sub, list)
+    len_whole = len(whole)
+    len_sub = len(sub)
+    assert len_whole > 0
+    assert len_sub > 0
+    
+    s = 0
+    while True:
+        s_whole = whole[s:]
+        try:
+            k_pos = s_whole.index(sub[0])
+        except ValueError:
+            return -1
+        
+        fail = False
+        for i in range(1, len_sub):
+            try:
+                if s_whole[k_pos + i] != sub[i]:
+                    fail = True
+                    break
+            except IndexError:
+                return -1
+        if fail:
+            s = s + k_pos + 1
+            continue
+        else:
+            return s + k_pos
+
+
+class CoreTagger(object):
+    def __init__(self, tokenizer, core_tags_as_special_tokens=False, include_tags=True):
+        self.tokenizer = tokenizer
+        if core_tags_as_special_tokens:
+            raise NotImplementedError
+        self.core_tags_as_special_tokens = core_tags_as_special_tokens
+        if not include_tags:
+            raise NotImplementedError
+        self.include_tags = include_tags
+
+        self.left_tag_to_id = {}
+        self.right_tag_to_id = {}
+
+    def generate_mask(self, token_ids, output_begin, sample):
+        mask = [0] * len(token_ids)
+        left_tag, right_tag = sample['output_core_tag_left'], sample['output_core_tag_right']
+        if left_tag not in self.left_tag_to_id:
+            if left_tag is None:
+                left_token_ids = None
+            else:
+                left_token_ids = self.tokenizer(left_tag, add_special_tokens=False, return_attention_mask=False)['input_ids']
+            self.left_tag_to_id[left_tag] = left_token_ids
+        else:
+            left_token_ids = self.left_tag_to_id[left_tag]
+        if right_tag not in self.right_tag_to_id:
+            if right_tag is None:
+                right_token_ids = None
+            else:
+                right_token_ids = self.tokenizer(right_tag, add_special_tokens=False, return_attention_mask=False)['input_ids']
+            self.right_tag_to_id[right_tag] = right_token_ids
+        else:
+            right_token_ids = self.right_tag_to_id[right_tag]
+
+        output_token_ids = token_ids[output_begin:]
+        if left_token_ids is None:
+            left_position = output_begin
+        elif len(output_token_ids) == 0:
+            left_position = None
+        else:
+            left_position = find_sub_sequence(output_token_ids, left_token_ids) + output_begin
+            if left_position == -1:
+                left_position = None
+        
+        if left_position is None:
+            return mask
+
+        if right_token_ids is None:
+            right_position = len(token_ids)
+            if token_ids[-1] == self.tokenizer.eos_token_id:
+                right_position -= 1
+        else:
+            right_position = find_sub_sequence(output_token_ids, right_token_ids) + output_begin
+            if right_position == -1:
+                right_position = len(token_ids)
+                if token_ids[-1] == self.tokenizer.eos_token_id:
+                    right_position -= 1
+            else:
+                right_position = min(right_position + len(right_token_ids), len(token_ids))
+        
+        for idx in range(left_position, right_position):
+            mask[idx] = 1
+
+        return mask
+
+
+class CoreTaggerGeneral(object):
+    def __init__(self, tokenizer, core_tags_as_special_tokens=False, include_tags=True):
+        self.tokenizer = tokenizer
+        if core_tags_as_special_tokens:
+            raise NotImplementedError
+        self.core_tags_as_special_tokens = core_tags_as_special_tokens
+        if not include_tags:
+            raise NotImplementedError
+        self.include_tags = include_tags
+
+        self.left_tag_to_id = {}
+        self.right_tag_to_id = {}
+
+    def generate_mask(self, token_ids, prompt_mask, sample):
+        mask = [0] * len(token_ids)
+        left_tag, right_tag = sample['output_core_tag_left'], sample['output_core_tag_right']
+        if left_tag not in self.left_tag_to_id:
+            if left_tag is None:
+                left_token_ids = None
+            else:
+                left_token_ids = self.tokenizer(left_tag, add_special_tokens=False, return_attention_mask=False)['input_ids']
+            self.left_tag_to_id[left_tag] = left_token_ids
+        else:
+            left_token_ids = self.left_tag_to_id[left_tag]
+        if right_tag not in self.right_tag_to_id:
+            if right_tag is None:
+                right_token_ids = None
+            else:
+                right_token_ids = self.tokenizer(right_tag, add_special_tokens=False, return_attention_mask=False)['input_ids']
+            self.right_tag_to_id[right_tag] = right_token_ids
+        else:
+            right_token_ids = self.right_tag_to_id[right_tag]
+
+        cur_ = 0
+        for idx in range(len(token_ids)):
+            if prompt_mask[idx] == 1 or token_ids[idx] == self.tokenizer.bos_token_id:
+                cur_ = 0
+                continue
+
+            if left_token_ids is None:
+                match_left = True
+            else:
+                match_left = True
+                try:
+                    for offset in range(len(left_token_ids)):
+                        if token_ids[idx + offset] != left_token_ids[offset]:
+                            match_left = False
+                            break
+                except IndexError:
+                    match_left = False
+            
+            if match_left:
+                cur_ = 1
+
+            mask[idx] = cur_
+
+            if right_token_ids is None:
+                continue
+
+            match_right = True
+            try:
+                for offset in range(len(right_token_ids)):
+                    if token_ids[idx - len(right_token_ids) + offset] != right_token_ids[offset]:
+                        match_right = False
+                        break
+            except IndexError:
+                match_right = False
+            
+            if match_right:
+                cur_ = 0
+
+        return mask

--- a/vlmeval/dataset/utils/llm4chem/utils/general_prompter.py
+++ b/vlmeval/dataset/utils/llm4chem/utils/general_prompter.py
@@ -1,0 +1,32 @@
+def get_chat_content(conversation, tokenize=False):
+    if tokenize:
+        raise NotImplementedError
+    available_roles = ('user', 'assistant')
+    content = ''
+    for idx, item in enumerate(conversation):
+        role = item['role']
+        assert role in available_roles, role
+        if idx % 2 == 0:
+            assert role == 'user'
+            content += '<s>'
+            item_content = '[INST] %s [/INST]' % item['content']
+            content += item_content
+        else:
+            assert role == 'assistant'
+            item_content = ' %s</s>' % item['content']
+            content += item_content
+    return content
+
+
+class GeneralPrompter(object):
+
+    def __init__(self, apply_chat_template_func, response_split='[/INST]'):
+        self.apply_chat_template_func = apply_chat_template_func
+        self.response_split = response_split
+
+    def generate_prompt(self, chat, tokenize=False, *args, **kargs) -> str:
+        res = self.apply_chat_template_func(chat, tokenize=tokenize, *args, **kargs)
+        return res
+
+    def get_response(self, output: str) -> str:
+        return output.split(self.response_split)[-1].strip()

--- a/vlmeval/dataset/utils/llm4chem/utils/metrics.py
+++ b/vlmeval/dataset/utils/llm4chem/utils/metrics.py
@@ -1,0 +1,623 @@
+import re
+from collections import defaultdict
+
+import numpy as np
+from tqdm.auto import tqdm
+
+from rdkit import Chem, RDLogger
+from rdkit.Chem import MACCSkeys
+from rdkit import DataStructs
+from rdkit.Chem import AllChem
+
+from transformers import BertTokenizerFast
+
+from nltk.translate.bleu_score import corpus_bleu
+from nltk.translate.meteor_score import meteor_score
+from rouge_score import rouge_scorer
+from sklearn.metrics import roc_auc_score, f1_score, precision_score, recall_score, matthews_corrcoef
+
+from .smiles_canonicalization import canonicalize_molecule_smiles, get_molecule_id
+
+
+RDLogger.DisableLog('rdApp.*')
+
+
+def convert_smiles_list_into_mol_list(smiles_list, raise_error_when_error=False):
+    mol_list = []
+    no_answer_labels = []
+    invalid_labels = []
+    for smiles in smiles_list:
+        if smiles == '':
+            mol = 'NA'
+            no_answer_labels.append(True)
+            if raise_error_when_error:
+                raise ValueError('SMILES is empty.')
+        else:
+            mol = Chem.MolFromSmiles(smiles)
+            if mol is None:
+                mol = 'INVALID'
+                invalid_labels.append(True)
+                if raise_error_when_error:
+                    raise ValueError('SMILES is not valid: %s' % smiles)
+        mol_list.append(mol)
+    
+    no_answer_labels = np.array(no_answer_labels)
+    invalid_labels = np.arange(invalid_labels)
+
+    return mol_list, no_answer_labels, invalid_labels
+
+
+def judge_exact_match(pred_can_smiles_list, gold_can_smiles_list):
+    assert len(pred_can_smiles_list) == len(gold_can_smiles_list)
+    exact_match_labels = []
+    for pred_smiles, gold_smiles_list in zip(pred_can_smiles_list, gold_can_smiles_list):
+        if pred_smiles is None or pred_smiles.strip() == '':
+            exact_match_labels.append(False)
+            continue
+        pred_smiles_inchi = get_molecule_id(pred_smiles)
+        sample_exact_match = False
+        for gold_smiles in gold_smiles_list:
+            assert gold_smiles is not None
+            gold_smiles_inchi = get_molecule_id(gold_smiles)
+            if pred_smiles_inchi == gold_smiles_inchi:
+                sample_exact_match = True
+                break
+        exact_match_labels.append(sample_exact_match)
+    return np.array(exact_match_labels)
+
+
+def calculate_fingerprint_similarity(pred_mol_list, gold_mols_list, morgan_r=2):
+    assert len(pred_mol_list) == len(gold_mols_list)
+    MACCS_sims = []
+    morgan_sims = []
+    RDK_sims = []
+    for pred_mol, gold_mol_list in zip(pred_mol_list, gold_mols_list):
+        if pred_mol is None or type(pred_mol) == str:
+            raise ValueError(type(pred_mol))
+        tmp_MACCS, tmp_RDK, tmp_morgan = 0, 0, 0
+        for gold_mol in gold_mol_list:
+            tmp_MACCS = max(tmp_MACCS, DataStructs.FingerprintSimilarity(MACCSkeys.GenMACCSKeys(gold_mol), MACCSkeys.GenMACCSKeys(pred_mol), metric=DataStructs.TanimotoSimilarity))
+            tmp_RDK = max(tmp_RDK, DataStructs.FingerprintSimilarity(Chem.RDKFingerprint(gold_mol), Chem.RDKFingerprint(pred_mol), metric=DataStructs.TanimotoSimilarity))
+            tmp_morgan = max(tmp_morgan, DataStructs.TanimotoSimilarity(AllChem.GetMorganFingerprint(gold_mol,morgan_r), AllChem.GetMorganFingerprint(pred_mol, morgan_r)))
+        MACCS_sims.append(tmp_MACCS)
+        RDK_sims.append(tmp_RDK)
+        morgan_sims.append(tmp_morgan)
+    maccs_sims_score = np.mean(MACCS_sims)
+    rdk_sims_score = np.mean(RDK_sims)
+    morgan_sims_score = np.mean(morgan_sims)
+    return maccs_sims_score, rdk_sims_score, morgan_sims_score
+
+
+def judge_multiple_match(pred_can_smiles_list, golds_can_smiles_list):
+    assert len(pred_can_smiles_list) == len(golds_can_smiles_list)
+    subset_labels = []
+    intersection_labels = []
+    for pred_smiles, gold_smiles_list in zip(pred_can_smiles_list, golds_can_smiles_list):
+        if pred_smiles is None:
+            subset_labels.append(False)
+            intersection_labels.append(False)
+            continue
+
+        pred_ele_set = set()
+        for smiles in pred_smiles.split('.'):
+            pred_ele_set.add(get_molecule_id(smiles, remove_duplicate=False))
+
+        intersection_label = False
+        subset_label = False
+        for gold_smiles in gold_smiles_list:
+            assert gold_smiles is not None
+            gold_ele_set = set()
+            for smiles in gold_smiles.split('.'):
+                gold_ele_set.add(get_molecule_id(smiles, remove_duplicate=False))
+
+            if len(pred_ele_set & gold_ele_set) > 0:
+                intersection_label = True
+                g_p = gold_ele_set - pred_ele_set
+                if len(g_p) >= 0 and len(pred_ele_set - gold_ele_set) == 0:
+                    subset_label = True
+                    break
+        intersection_labels.append(intersection_label)
+        subset_labels.append(subset_label)
+    
+    return intersection_labels, subset_labels
+
+
+def calculate_smiles_metrics(
+        preds_smiles_list, 
+        golds_smiles_list,
+        metrics=('exact_match', 'fingerprint')
+):
+    num_all = len(preds_smiles_list)
+    assert num_all > 0
+    assert num_all == len(golds_smiles_list)
+    k = len(preds_smiles_list[0])
+
+    dk_pred_smiles_list_dict = {}
+    dk_pred_no_answer_labels_dict = {}
+    dk_pred_invalid_labels_dict = {}
+    for dk in range(k):
+        dk_pred_smiles_list_dict[dk] = []
+        dk_pred_no_answer_labels_dict[dk] = []
+        dk_pred_invalid_labels_dict[dk] = []
+    for pred_smiles_list in tqdm(preds_smiles_list):
+        if pred_smiles_list is None:
+            for dk in range(k):
+                dk_pred_no_answer_labels_dict[dk].append(True)
+                dk_pred_invalid_labels_dict[dk].append(False)
+                dk_pred_smiles_list_dict[dk].append(None)
+            continue
+        assert len(pred_smiles_list) == k
+        for dk, item in enumerate(pred_smiles_list):
+            # item = item.strip()
+            if item == '' or item is None:
+                item = None
+                dk_pred_no_answer_labels_dict[dk].append(True)
+                dk_pred_invalid_labels_dict[dk].append(False)
+            else:
+                dk_pred_no_answer_labels_dict[dk].append(False)
+                item = canonicalize_molecule_smiles(item)
+                if item is None:
+                    dk_pred_invalid_labels_dict[dk].append(True)
+                else:
+                    dk_pred_invalid_labels_dict[dk].append(False)
+            dk_pred_smiles_list_dict[dk].append(item)
+    
+    new_list = []
+    for gold_smiles_list in tqdm(golds_smiles_list):
+        sample_gold_smiles_list = []
+        for gold in gold_smiles_list:
+            item = gold.strip()
+            new_item = canonicalize_molecule_smiles(item, return_none_for_error=False)
+            # if new_item is None:
+            #     new_item = item  #TODO
+            # assert new_item is not None, item
+            sample_gold_smiles_list.append(new_item)
+        new_list.append(sample_gold_smiles_list)
+    golds_smiles_list = new_list
+
+    metric_results = {'num_all': num_all}
+
+    tk_pred_no_answer_labels = np.array([True] * num_all)
+    tk_pred_invalid_labels = np.array([True] * num_all)
+    for dk in range(k):
+        dk_no_answer_labels = dk_pred_no_answer_labels_dict[dk]
+        dk_invalid_labels = dk_pred_invalid_labels_dict[dk]
+        tk_pred_no_answer_labels = tk_pred_no_answer_labels & dk_no_answer_labels
+        tk_pred_invalid_labels = tk_pred_invalid_labels & dk_invalid_labels
+        metric_results['num_t%d_no_answer' % (dk + 1)] = tk_pred_no_answer_labels.sum().item()
+        metric_results['num_t%d_invalid' % (dk + 1)] = tk_pred_invalid_labels.sum().item()
+    
+    # d1_no_answer_labels = dk_pred_no_answer_labels_dict[0]
+    # # print(np.array(d1_no_answer_labels).sum().item())
+    # for label, item in zip(d1_no_answer_labels, preds_smiles_list):
+    #     if label:
+    #         print(item)
+
+    for metric in metrics:
+        if metric == 'exact_match':
+            tk_exact_match_labels = np.array([False] * num_all)
+            for dk in range(k):
+                dk_pred_smiles_list = dk_pred_smiles_list_dict[dk]
+                dk_exact_match_labels = judge_exact_match(dk_pred_smiles_list, golds_smiles_list)
+                tk_exact_match_labels = tk_exact_match_labels | dk_exact_match_labels
+                metric_results['num_t%d_exact_match' % (dk + 1)] = tk_exact_match_labels.sum().item()
+        elif metric == 'fingerprint':
+            d1_pred_mol_list = []
+            gold_mols_list = []
+            for pred_smiles, gold_smiles_list, no_answer, invalid in zip(dk_pred_smiles_list_dict[0], golds_smiles_list, dk_pred_no_answer_labels_dict[0], dk_pred_invalid_labels_dict[0]):
+                if pred_smiles is None or pred_smiles.strip() == '' or no_answer is True or invalid is True:
+                    continue
+                pred_mol = Chem.MolFromSmiles(pred_smiles)
+                if pred_mol is None:  # TODO
+                    continue
+                assert pred_mol is not None, pred_smiles
+                gold_mol_list = []
+                for gold_smiles in gold_smiles_list:
+                    gold_mol = Chem.MolFromSmiles(gold_smiles)
+                    # if gold_mol is None:
+                    #     continue  # TODO
+                    assert gold_mol is not None, gold_smiles
+                    gold_mol_list.append(gold_mol)
+                # if len(gold_mol_list) == 0:
+                #     continue  # TODO
+                d1_pred_mol_list.append(pred_mol)
+                gold_mols_list.append(gold_mol_list)
+            maccs_sims_score, rdk_sims_score, morgan_sims_score = calculate_fingerprint_similarity(d1_pred_mol_list, gold_mols_list)
+            metric_results['t1_maccs_fps'] = maccs_sims_score
+            metric_results['t1_rdk_fps'] = rdk_sims_score
+            metric_results['t1_morgan_fps'] = morgan_sims_score
+        elif metric == 'multiple_match':
+            tk_intersection_labels = np.array([False] * num_all)
+            tk_subset_labels = np.array([False] * num_all)
+            for dk in range(k):
+                dk_intersection_labels, dk_subset_labels = judge_multiple_match(dk_pred_smiles_list_dict[dk], golds_smiles_list)
+                tk_intersection_labels = tk_intersection_labels | dk_intersection_labels
+                tk_subset_labels = tk_subset_labels | dk_subset_labels
+                metric_results['num_t%d_subset' % (dk + 1)] = tk_intersection_labels.sum().item()
+                metric_results['num_t%d_intersection' % (dk + 1)] = tk_intersection_labels.sum().item()
+        else:
+            raise ValueError(metric)
+    
+    return metric_results
+
+
+def judge_string_exact_match(pred_string_list, golds_string_list):
+    exact_match_labels = []
+    for pred_string, gold_string_list in zip(pred_string_list, golds_string_list):
+        exact_match = False
+        for gold_string in gold_string_list:
+            if pred_string == gold_string:
+                exact_match = True
+                break
+        exact_match_labels.append(exact_match)
+    return np.array(exact_match_labels)
+
+
+def judge_string_split_match(pred_string_list, golds_string_list, separater=';'):
+    exact_match_labels = []
+    for pred_string, gold_string_list in zip(pred_string_list, golds_string_list):
+        pred_item = tuple(sorted(pred_string.split(separater)))
+        exact_match = False
+        for gold_string in gold_string_list:
+            gold_item = tuple(sorted(gold_string.split(separater)))
+            if pred_item == gold_item:
+                exact_match = True
+                break
+        exact_match_labels.append(exact_match)
+    return np.array(exact_match_labels)
+
+
+def parse_molecule(molecular_formula):
+    valid = re.match('([A-Za-z]\d*)+([\+\-]\d*)*$', molecular_formula)
+    if valid is None:
+        raise ValueError("Molecular formula \"%s\" is not valid." % molecular_formula)
+
+    stack = [defaultdict(int)]
+
+    def _parse_formula(formula, _stack):
+
+        # Set remainder equal to 'None'
+        r = None
+
+        # Regular expression matching for each of the three cases:
+        atom = re.match(r'([A-Z][a-z]?)(\d+)?', formula)
+        opening = re.match(r'[\(\[\{]', formula)
+        closing = re.match(r'[\)\]\}](\d+)?', formula)
+
+        # If atom is identified:
+        if atom:
+            r = formula[len(atom.group()):]
+            _stack[-1][atom.group(1)] += int(atom.group(2) or 1)
+
+        # If opening brackets encountered:
+        elif opening:
+            r = formula[len(opening.group()):] #this sets the remainder equal to everything after the opening brackets
+            _stack.append(defaultdict(int)) 
+
+        # If closing brackets encountered:
+        elif closing:
+            r = formula[len(closing.group()):] #this sets the remainder equal to everything after the closing brackets
+            for (k, v) in _stack.pop().items():
+                _stack[-1][k] += v * int(closing.group(1) or 1) #v times amount of molecule k, depending on nesting
+
+        # If anything remains, process remainders recursively as nested formulas:
+        if r:
+            _parse_formula(r, _stack)
+
+        return dict(_stack[0])
+    
+    result = _parse_formula(molecular_formula, stack)
+
+    charge = re.search('[\+\-]\d*', molecular_formula)
+    if charge is not None:
+        charge_str = charge.group()
+        charge_type = charge_str[0]
+        if len(charge_str) == 1:
+            charge_num = 1
+        else:
+            charge_num = int(charge_str[1:])
+        result[charge_type] = charge_num
+
+    return result
+
+
+def count_element_match(pred_formula_list, golds_formula_list):
+    assert len(pred_formula_list) == len(golds_formula_list)
+    ele_match_labels = []
+    ele_invalid_labels = []
+    for pred_formula, gold_formula_list in zip(pred_formula_list, golds_formula_list):
+        if pred_formula == '' or pred_formula is None:
+            ele_invalid_labels.append(False)
+            ele_match_labels.append(False)
+            continue
+        try:
+            pred_ele = parse_molecule(pred_formula)
+        except KeyboardInterrupt:
+            raise
+        except:
+            # print(pred_formula)
+            # print('=====')
+            ele_invalid_labels.append(True)
+            ele_match_labels.append(False)
+            continue
+        ele_invalid_labels.append(False)
+        ele_match = False
+        for gold_formula in gold_formula_list:
+            gold_ele = parse_molecule(gold_formula)
+            if pred_ele == gold_ele:
+                ele_match = True
+                break
+        ele_match_labels.append(ele_match)
+    return ele_match_labels, ele_invalid_labels
+
+
+def calculate_formula_metrics(
+        preds_formula_list,
+        golds_formula_list,
+        metrics=('element_match',)
+):
+    """
+    Calculate metrics for molecular formula. Here we use element_match (equals to exact_match used in our paper) by default, which compares the atom numbers and ignore the orders.
+    For example, C5H8 == H8C5.
+    """
+    num_all = len(preds_formula_list)
+    assert len(preds_formula_list) == len(golds_formula_list)
+    try:
+        k = len(preds_formula_list[0])
+    except IndexError:
+        print(preds_formula_list)
+        raise
+    dk_pred_formula_list_dict = dict()
+    for dk in range(k):
+        dk_pred_formula_list_dict[dk] = []
+    for sample_formula_list in preds_formula_list:
+        if sample_formula_list is None:
+            for dk in range(k):
+                dk_pred_formula_list_dict[dk].append('')
+            continue
+        assert len(sample_formula_list) == k
+        for dk in range(k):
+            item = sample_formula_list[dk]
+            dk_pred_formula_list_dict[dk].append(item)
+    golds_formula_list = [[small_item.strip() for small_item in item] for item in golds_formula_list]
+    new_golds_formula_list = []
+    for item in golds_formula_list:
+        new_item = []
+        for small_item in item:
+            small_item = small_item.strip()
+            assert small_item != ''
+            new_item.append(small_item)
+        new_golds_formula_list.append(new_item)
+    golds_formula_list = new_golds_formula_list
+
+
+    metric_results = {'num_all': num_all}
+
+    tk_no_answer_labels = np.array([True] * num_all)
+    for dk in range(k):
+        dk_pred_formula_list = dk_pred_formula_list_dict[dk]
+        dk_no_answer_labels = []
+        for item in dk_pred_formula_list:
+            if item == '' or item is None:
+                dk_no_answer_labels.append(True)
+            else:
+                dk_no_answer_labels.append(False)
+        dk_no_answer_labels = np.array(dk_no_answer_labels)
+        tk_no_answer_labels = tk_no_answer_labels & dk_no_answer_labels
+        metric_results['num_t%d_no_answer' % (dk + 1)] = tk_no_answer_labels.sum().item()
+
+    for metric in metrics:
+        if metric == 'exact_match':
+            tk_exact_match_labels = np.array([False] * num_all)
+            for dk in range(k):
+                dk_pred_formula_list = dk_pred_formula_list_dict[dk]
+                dk_exact_match_labels = judge_string_exact_match(dk_pred_formula_list, golds_formula_list)
+                tk_exact_match_labels = tk_exact_match_labels | dk_exact_match_labels
+                metric_results['num_t%d_exact_match' % (dk + 1)] = tk_exact_match_labels.sum().item()
+        elif metric == 'element_match':
+            tk_ele_match_labels = np.array([False] * num_all)
+            tk_formula_invalid_labels = np.array([True] * num_all)
+            for dk in range(k):
+                dk_pred_formula_list = dk_pred_formula_list_dict[dk]
+                dk_ele_match_labels, dk_formula_invalid_labels = count_element_match(dk_pred_formula_list, golds_formula_list)
+                tk_ele_match_labels = tk_ele_match_labels | dk_ele_match_labels
+                tk_formula_invalid_labels = tk_formula_invalid_labels & dk_formula_invalid_labels
+                metric_results['num_t%d_ele_match' % (dk + 1)] = tk_ele_match_labels.sum().item()
+                metric_results['num_t%d_formula_invalid' % (dk + 1)] = tk_formula_invalid_labels.sum().item()
+        elif metric == 'split_match':
+            tk_exact_match_labels = np.array([False] * num_all)
+            for dk in range(k):
+                dk_pred_formula_list = dk_pred_formula_list_dict[dk]
+                dk_exact_match_labels = judge_string_split_match(dk_pred_formula_list, golds_formula_list)
+                tk_exact_match_labels = tk_exact_match_labels | dk_exact_match_labels
+                metric_results['num_t%d_split_match' % (dk + 1)] = tk_exact_match_labels.sum().item()
+        else:
+            raise ValueError(metric)
+    
+    return metric_results
+
+
+def calculate_text_metrics(pred_text_list, gold_text_list, text_model='allenai/scibert_scivocab_uncased', text_trunc_length=512):
+    assert len(pred_text_list) == len(gold_text_list)
+    pred_text_list = [(item[0].strip() if item is not None else '') for item in pred_text_list]
+    gold_text_list = [item[0].strip() for item in gold_text_list]
+
+    num_no_answer = 0
+    for pred_formula in pred_text_list:
+        if pred_formula == '':
+            num_no_answer += 1
+
+    text_tokenizer = BertTokenizerFast.from_pretrained(text_model)
+
+    meteor_scores = []
+
+    references = []
+    hypotheses = []
+
+    for i, (gt, out) in enumerate(zip(gold_text_list, pred_text_list)):
+        if out == '':
+            continue
+
+        gt_tokens = text_tokenizer.tokenize(gt, truncation=True, max_length=text_trunc_length,
+                                            padding='max_length')
+        gt_tokens = list(filter(('[PAD]').__ne__, gt_tokens))
+        gt_tokens = list(filter(('[CLS]').__ne__, gt_tokens))
+        gt_tokens = list(filter(('[SEP]').__ne__, gt_tokens))
+
+        out_tokens = text_tokenizer.tokenize(out, truncation=True, max_length=text_trunc_length,
+                                            padding='max_length')
+        out_tokens = list(filter(('[PAD]').__ne__, out_tokens))
+        out_tokens = list(filter(('[CLS]').__ne__, out_tokens))
+        out_tokens = list(filter(('[SEP]').__ne__, out_tokens))
+
+        references.append([gt_tokens])
+        hypotheses.append(out_tokens)
+
+        mscore = meteor_score([gt_tokens], out_tokens)
+        meteor_scores.append(mscore)
+
+    bleu2 = corpus_bleu(references, hypotheses, weights=(.5,.5))
+    bleu4 = corpus_bleu(references, hypotheses, weights=(.25,.25,.25,.25))
+
+    _meteor_score = np.mean(meteor_scores)
+
+    scorer = rouge_scorer.RougeScorer(['rouge1', 'rouge2', 'rougeL'])
+
+    rouge_scores = []
+
+    references = []
+    hypotheses = []
+
+    for i, (gt, out) in enumerate(zip(gold_text_list, pred_text_list)):
+        if out == '':
+            continue
+
+        rs = scorer.score(out, gt)
+        rouge_scores.append(rs)
+
+    rouge_1 = np.mean([rs['rouge1'].fmeasure for rs in rouge_scores])
+    rouge_2 = np.mean([rs['rouge2'].fmeasure for rs in rouge_scores])
+    rouge_l = np.mean([rs['rougeL'].fmeasure for rs in rouge_scores])
+
+    result = {
+        'num_all': len(pred_text_list),
+        'num_no_answer': num_no_answer,
+        'bleu2': bleu2,
+        'bleu4': bleu4,
+        'rouge_1': rouge_1,
+        'rouge_2': rouge_2,
+        'rouge_l': rouge_l,
+        'meteor_score': _meteor_score,
+    }
+
+    return result
+
+
+def calculate_number_metrics(pred_text_list, gold_text_list):
+    assert len(pred_text_list) == len(gold_text_list)
+    num_all = len(pred_text_list)
+    metrics = {}
+    metrics['num_all'] = num_all
+    num_no_answer = 0
+    num_invalid = 0
+    new_pred_text_list, new_gold_text_list = [], []
+    for (pred_item, gold_item) in zip(pred_text_list, gold_text_list):
+        if pred_item is None:
+            num_no_answer += 1
+            continue
+        assert len(pred_item) == 1
+        assert len(gold_item) == 1
+        pred_item = pred_item[0]
+        gold_item = gold_item[0]
+        if pred_item == '':
+            num_no_answer += 1
+            continue
+        try:
+            pred_item = float(pred_item)
+        except (SyntaxError, ValueError):
+            # print("\"%s\"" % pred_item)
+            num_invalid += 1
+            continue
+        gold_item = float(gold_item)
+        new_pred_text_list.append(pred_item)
+        new_gold_text_list.append(gold_item)
+    
+    new_pred_text_list = np.array(new_pred_text_list)
+    new_gold_text_list = np.array(new_gold_text_list)
+    score = np.sqrt(((new_pred_text_list - new_gold_text_list) ** 2).mean())
+    
+    metrics['num_no_answer'] = num_no_answer
+    metrics['num_invalid'] = num_invalid
+    metrics['RMSE'] = score
+
+    return metrics
+
+
+def calculate_boolean_metrics(pred_text_list, gold_text_list):
+    assert len(pred_text_list) == len(gold_text_list)
+    num_all = len(pred_text_list)
+    metrics = {}
+    metrics['num_all'] = num_all
+    num_no_answer = 0
+    num_invalid = 0
+    num_correct = 0
+    new_pred_text_list, new_gold_text_list = [], []
+    for (pred_item, gold_item) in zip(pred_text_list, gold_text_list):
+        if pred_item is None or pred_item == '':
+            num_no_answer += 1
+            continue
+        assert len(pred_item) == 1
+        assert len(gold_item) == 1
+        pred_item = pred_item[0].strip().lower()
+        gold_item = gold_item[0].strip().lower()
+        if pred_item == '':
+            num_no_answer += 1
+            continue
+        if pred_item not in ('yes', 'no'):
+            num_invalid += 1
+            continue
+        pred_item = 1 if pred_item == 'yes' else 0
+        gold_item = 1 if gold_item == 'yes' else 0
+        new_pred_text_list.append(pred_item)
+        new_gold_text_list.append(gold_item)
+        if gold_item == pred_item:
+            num_correct += 1
+
+    metrics['num_no_answer'] = num_no_answer
+    metrics['num_invalid'] = num_invalid
+    metrics['num_correct'] = num_correct
+
+    # return metrics
+
+    new_gold_text_list = np.array(new_gold_text_list)
+    new_pred_text_list = np.array(new_pred_text_list)
+
+    try:
+        macro_roc_auc_score = roc_auc_score(new_gold_text_list, new_pred_text_list)
+    except:
+        macro_roc_auc_score = float('nan')
+    try:
+        f1 = f1_score(new_gold_text_list, new_pred_text_list)
+    except:
+        f1 = float('nan')
+    metrics['roc_auc_score'] = macro_roc_auc_score
+    try:
+        metrics['precision'] = precision_score(new_gold_text_list, new_pred_text_list)
+    except:
+        metrics['precision'] = float('nan')
+    try:
+        metrics['recall'] = recall_score(new_gold_text_list, new_pred_text_list)
+    except:
+        metrics['recall'] = float('nan')
+    metrics['f1_score'] = f1
+
+    no_mask = (new_gold_text_list == 0)
+    new_gold_text_list[no_mask] = -1
+    no_mask = (new_pred_text_list == 0)
+    new_pred_text_list[no_mask] = -1
+    try:
+        metrics['mcc'] = matthews_corrcoef(new_gold_text_list, new_pred_text_list)
+    except:
+        metrics['mcc'] = float('nan')
+
+    return metrics

--- a/vlmeval/dataset/utils/llm4chem/utils/smiles_canonicalization.py
+++ b/vlmeval/dataset/utils/llm4chem/utils/smiles_canonicalization.py
@@ -1,0 +1,143 @@
+from rdkit import Chem, RDLogger
+from rdchiral.chiral import copy_chirality
+from rdkit.Chem.AllChem import AssignStereochemistry
+
+
+RDLogger.DisableLog('rdApp.*')
+
+
+def canonicalize(smiles, isomeric=False, canonical=True, kekulize=False):
+    # When canonicalizing a SMILES string, we typically want to
+    # run Chem.RemoveHs(mol), but this will try to kekulize the mol
+    # which is not required for canonical SMILES.  Instead, we make a
+    # copy of the mol retaining only the information we desire (not explicit Hs)
+    # Then, we sanitize the mol without kekulization.  copy_atom and copy_edit_mol
+    # Are used to create this clean copy of the mol.
+    def copy_atom(atom):
+        new_atom = Chem.Atom(atom.GetSymbol())
+        new_atom.SetFormalCharge(atom.GetFormalCharge())
+        if atom.GetIsAromatic() and atom.GetNoImplicit():
+            new_atom.SetNumExplicitHs(atom.GetNumExplicitHs())
+            #elif atom.GetSymbol() == 'N':
+            #    print(atom.GetSymbol())
+            #    print(atom.GetImplicitValence())
+            #    new_atom.SetNumExplicitHs(-atom.GetImplicitValence())
+            #elif atom.GetSymbol() == 'S':
+            #    print(atom.GetSymbol())
+            #    print(atom.GetImplicitValence())
+        return new_atom
+
+    def copy_edit_mol(mol):
+        new_mol = Chem.RWMol(Chem.MolFromSmiles(''))
+        for atom in mol.GetAtoms():
+            new_atom = copy_atom(atom)
+            new_mol.AddAtom(new_atom)
+        for bond in mol.GetBonds():
+            a1 = bond.GetBeginAtom().GetIdx()
+            a2 = bond.GetEndAtom().GetIdx()
+            bt = bond.GetBondType()
+            new_mol.AddBond(a1, a2, bt)
+            new_bond = new_mol.GetBondBetweenAtoms(a1, a2)
+            new_bond.SetBondDir(bond.GetBondDir())
+            new_bond.SetStereo(bond.GetStereo())
+        for new_atom in new_mol.GetAtoms():
+            atom = mol.GetAtomWithIdx(new_atom.GetIdx())
+            copy_chirality(atom, new_atom)
+        return new_mol
+
+    smiles = smiles.replace(" ", "")  
+    tmp = Chem.MolFromSmiles(smiles, sanitize=False)
+    tmp.UpdatePropertyCache()
+    new_mol = copy_edit_mol(tmp)
+    #Chem.SanitizeMol(new_mol, sanitizeOps=Chem.SanitizeFlags.SANITIZE_ALL)
+    if not kekulize:
+        Chem.SanitizeMol(new_mol, sanitizeOps=Chem.SanitizeFlags.SANITIZE_SETAROMATICITY | Chem.SanitizeFlags.SANITIZE_PROPERTIES | Chem.SanitizeFlags.SANITIZE_ADJUSTHS, catchErrors=True)
+    else:
+        Chem.SanitizeMol(new_mol, sanitizeOps=Chem.SanitizeFlags.SANITIZE_KEKULIZE | Chem.SanitizeFlags.SANITIZE_PROPERTIES | Chem.SanitizeFlags.SANITIZE_ADJUSTHS, catchErrors=True)
+   
+    AssignStereochemistry(new_mol, cleanIt=False, force=True, flagPossibleStereoCenters=True)
+    
+    new_smiles = Chem.MolToSmiles(new_mol, isomericSmiles=isomeric, canonical=canonical)
+    return new_smiles
+
+
+def canonicalize_molecule_smiles(smiles, return_none_for_error=True, skip_mol=False, sort_things=True, isomeric=True, kekulization=True, allow_empty_part=False):
+    things = smiles.split('.')
+    if skip_mol:
+        new_things = things
+    else:
+        new_things = []
+        for thing in things:
+            try:
+                if thing == '' and not allow_empty_part:
+                    raise ValueError('SMILES contains empty part.')
+
+                mol = Chem.MolFromSmiles(thing)
+                # print(f"smiles = {thing} mol = {mol}")
+                if mol is None: 
+                    return thing
+                assert mol is not None
+                for atom in mol.GetAtoms():
+                    atom.SetAtomMapNum(0)
+                thing_smiles = Chem.MolToSmiles(mol, kekuleSmiles=False, isomericSmiles=isomeric)
+                thing_smiles = Chem.MolFromSmiles(thing_smiles)
+                thing_smiles = Chem.MolToSmiles(thing_smiles, kekuleSmiles=False, isomericSmiles=isomeric)
+                thing_smiles = Chem.MolFromSmiles(thing_smiles)
+                thing_smiles = Chem.MolToSmiles(thing_smiles, kekuleSmiles=False, isomericSmiles=isomeric)
+                assert thing_smiles is not None
+                can_in = thing_smiles
+                can_out = canonicalize(thing_smiles, isomeric=isomeric)
+                assert can_out is not None, can_in
+                thing_smiles = can_out
+                if kekulization:
+                    thing_smiles = keku_mid = Chem.MolFromSmiles(thing_smiles)
+                    assert keku_mid is not None, 'Before can: %s\nAfter can: %s' % (can_in, can_out)
+                    thing_smiles = Chem.MolToSmiles(thing_smiles, kekuleSmiles=True, isomericSmiles=isomeric)
+            except KeyboardInterrupt:
+                raise
+            except:
+                if return_none_for_error:
+                    return None
+                else:
+                    raise
+            new_things.append(thing_smiles)
+    if sort_things:
+        new_things = sorted(new_things)
+    new_things = '.'.join(new_things)
+    return new_things
+
+
+def canonicalize_reaction_smiles(smiles, return_none_for_error=True, return_segs=False, skip_mol=False, sort_things=True, isomeric=True, kekulization=True):
+    segs = smiles.split('>')
+    assert len(segs) == 3
+    new_segs = []
+    for seg in segs:
+        if seg != '':
+            new_things = canonicalize_molecule_smiles(seg, return_none_for_error=return_none_for_error, skip_mol=skip_mol, sort_things=sort_things, isomeric=isomeric, kekulization=kekulization)
+            if return_none_for_error and new_things is None:
+                return None
+            new_segs.append(new_things)
+        else:
+            new_segs.append('')
+    
+    if return_segs:
+        return tuple(new_segs)
+    
+    smiles = '>'.join(new_segs)
+    return smiles
+
+
+def get_molecule_id(smiles, remove_duplicate=True):
+    if remove_duplicate:
+        assert ';' not in smiles
+        all_inchi = set()
+        for part in smiles.split('.'):
+            inchi = get_molecule_id(part, remove_duplicate=False)
+            all_inchi.add(inchi)
+        all_inchi = tuple(sorted(all_inchi))
+        return all_inchi
+    else:
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            return ""
+        return Chem.MolToInchi(mol)


### PR DESCRIPTION

**Add support for the LLM4Chem dataset and its subtasks**

This PR adds dataset integration for [LLM4Chem](https://github.com/OSU-NLP-Group/LLM4Chem)(https://github.com/OSU-NLP-Group/LLM4Chem) with support for the following subtasks:

```
'forward_synthesis',
'retrosynthesis',
'molecule_captioning',
'molecule_generation',
'name_conversion-i2f',
'name_conversion-i2s',
'name_conversion-s2f',
'name_conversion-s2i',
'property_prediction-esol',
'property_prediction-lipo',
'property_prediction-bbbp',
'property_prediction-clintox',
'property_prediction-hiv',
'property_prediction-sider',
'retrosynthesis_uspto50k'
```

**Notes:**

* `retrosynthesis_uspto50k` comes from [otori-bird/retrosynthesis](https://github.com/otori-bird/retrosynthesis)(https://github.com/otori-bird/retrosynthesis) and has been integrated seamlessly with the other retrosynthesis tasks.
* The content within `<think></think>` will be removed.
* Some metrics currently support only top-1; top-k support is yet to be developed (mainly depending on framework support).