### PR TITLE
Support Mol-Instruction and PEER dataset for Scireasoner evaluation

### DIFF
--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -122,10 +122,10 @@ class ConcatDataset(ImageBaseDataset):
             'protein_design'
         ],
         'PEER': [
-            # 'solubility',
+            'solubility',
             'stability',
-            # 'human_ppi',
-            # 'yeast_ppi'
+            'human_ppi',
+            'yeast_ppi'
         ]
     }
 


### PR DESCRIPTION
- Mol-Instruction and PEER dataset for Scireasoner evaluation
- tsv_files still are stored in local (need to fix?)